### PR TITLE
Make --cwd and --keepwd incompatible

### DIFF
--- a/tmpdir.py
+++ b/tmpdir.py
@@ -152,7 +152,11 @@ stay in current working directory
 set the environment variable TMPDIR to the absolute path to
 the created tmpdir
 """)
-    return parser.parse_args(args)
+
+    args = parser.parse_args(args)
+
+    if args.cwd and args.keepwd:
+        raise parser.error("--keepwd and --cwd are incompatible options")
 
 
 def main():


### PR DESCRIPTION
Previously, when specifying both `--keepwd` and `--cwd`,
`tmpdir.py` would act as if only `--keepwd` was set:

```
$ ./tmpdir.py --cwd --keepwd pwd
/home/nbraud/devel/py/tmpdir.py
```


This instead makes the options incompatible and provides an error message:

```
$ ./tmpdir.py --cwd --keepwd pwd
usage: tmpdir.py [-h] [-d PATH] [-p TEXT] [-s TEXT] [-c PATH] [-g] [-k] [-e]
                 COMMAND ...
tmpdir.py: error: --keepwd and --cwd are incompatible options
```