### PR TITLE
Provide a context manager

### DIFF
--- a/tmpdir.py
+++ b/tmpdir.py
@@ -3,6 +3,7 @@
 # Do Something With A Temporary Directory
 # See also https://github.com/oleks/tmpdir.py
 
+# Copyright (c) 2018 Nicolas Braud-Santoni <nicoo@realraum.at>
 # Copyright (c) 2016 Oleks <oleks@oleks.info>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/tmpdir.py
+++ b/tmpdir.py
@@ -31,7 +31,29 @@ import subprocess
 import sys
 import tempfile
 
+from contextlib import contextmanager
 from typing import List
+
+
+@contextmanager
+def tmpdir(copy=None,
+           dir=tempfile.gettempdir(),
+           prefix=tempfile.gettempprefix(),
+           suffix=""):
+
+    tmp = tempfile.mkdtemp(dir=dir, prefix=prefix, suffix=suffix)
+
+    try:
+        if copy:
+            if os.path.isfile(copy):
+                shutil.copy2(copy, tmp)
+            else:
+                copytree(copy, tmp)
+
+        yield tmp
+
+    finally:
+        shutil.rmtree(tmp)
 
 
 # http://stackoverflow.com/a/12514470/5801152


### PR DESCRIPTION
This changes add a `tmpdir()` context manager that can be used from Python code, making `tmpdir.py` more useful as a library.

Here is an example of how it can be used:

```
with tmpdir() as tmp:
     print(subprocess.check_output(['pwd'], cwd=tmp)
```